### PR TITLE
Improve 2716 support, structural improvements, standardised conventions and commentary

### DIFF
--- a/send_binary.py
+++ b/send_binary.py
@@ -5,7 +5,7 @@ import serial
 def send_file(serial_port, baud_rate, file_path, block_size, rom_pincount  ):
     try:
         # Open serial port
-        ser = serial.Serial(serial_port, baud_rate, timeout=0.001, inter_byte_timeout=0.001, dsrdtr=True)
+        ser = serial.Serial(serial_port, baud_rate, timeout=5, inter_byte_timeout=0.001, dsrdtr=True)
         # Disable the DTR signal to prevent reset
         ser.dtr = False
         time.sleep(2)
@@ -20,30 +20,56 @@ def send_file(serial_port, baud_rate, file_path, block_size, rom_pincount  ):
             ser.write(bytes([block_size]))
             ser.write(b'\x10') # Stop page.. Fix
             ser.write(bytes([rom_pincount])) # ROM pin count
+            block_count = 0
+            error_count = 0
+            transfer_started = False
+            start_time = time.time()
             # Read the file and send in blocks
             while True:
                 # Wait for the recipient's readiness signal (AA byte)
                 byte = ser.read(1)
+                
                 if byte == b'\xAA':
-                    # Read the next block of data
+                    if not transfer_started:
+                        print("✓ Arduino ready - starting transfer...\n")
+                        transfer_started = True
+
+                    block_count += 1
                     data = f.read(block_size)
+                    
                     if not data:
+                        ser.write(b"\x00")    # send a zero-length block to indicate EOF to arduino
+                        ser.flush()
+                        elapsed = time.time() - start_time
+                        rate = block_count / elapsed
+                        print("")
+                        print(f"Block {block_count} | {elapsed:.1f}s | {rate:.1f} blocks/s")
+                        print(f"\n{'='*50}")
+                        print(f"Transfer Summary:")
+                        print(f"  Blocks sent: {block_count}")
+                        print(f"  Time: {elapsed:.2f}s")
+                        print(f"  Rate: {block_count/elapsed:.1f} blocks/s")
+                        if error_count > 0:
+                            print(f"  Errors: {error_count}")
+                        print(f"{'='*50}")
                         break
-                    # Send the data block
+                    
+                    # Print block stats for first and then every 5 blocks
+                    if block_count % 5 == 0 or block_count == 1:
+                        elapsed = time.time() - start_time
+                        rate = block_count / elapsed
+                        if block_count != 1: print("")
+                        print(f"Block {block_count} | {elapsed:.1f}s | {rate:.1f} blocks/s")
+                        if block_count == 1: print(".", end="", flush=True)
+                    else:
+                        print(".", end="", flush=True)
+                    
                     ser.write(data)
-                    #print(".", end="")
-                # Record end time
-                else:
-                    pass
-
-
-        end_time = time.time()
-        # Calculate total duration
-        total_duration = end_time - start_time
-        print(f"File sent in {total_duration:.2f} seconds")
-
-        print("\nFile sent successfully!")
-
+                    ser.flush()
+                    time.sleep(0.02)  # 20ms delay to let Arduino process
+                elif byte != b'\x00':   # surpress 0x00 bytes - caused as a result of D0/D1 being low during programming??
+                    error_count += 1
+                    print(f"\nWarning: Expected 0xAA, got 0x{byte.hex()} (error #{error_count})")
     except Exception as e:
         print("Error:", e)
     finally:

--- a/software/Arduino/ArduinoProgrammerFirmwarePrototype/ArduinoProgrammerFirmwarePrototype.ino
+++ b/software/Arduino/ArduinoProgrammerFirmwarePrototype/ArduinoProgrammerFirmwarePrototype.ino
@@ -75,7 +75,6 @@
       2025-11-19 – Major enhancements and 2716-specific improvements (TheSubWayKing)
  --------------------------------------------------------------------------------------------------
 */
-
 #include <Wire.h>
 #include <Adafruit_GFX.h>
 #include <Adafruit_SSD1306.h>
@@ -129,8 +128,16 @@ constexpr uint8_t REG_DISABLE   = 0b10000000;    // Disable regulator
 // ===== EPROM Chip Parameters =====
 constexpr uint8_t ROM_PIN_COUNT = 28;            // Default ROM pin count
 constexpr uint32_t ROM_SIZE = 4096;              // Default ROM size
+constexpr uint32_t MAX_ROM_SIZE_16BIT = 65536;   // Maximum 16 Bit ROM size
 uint8_t romPinCount = ROM_PIN_COUNT;             // ROM pin count
 uint32_t romSize = ROM_SIZE;                     // ROM size - We need to support more than 16 address bits
+
+// ===== Timing Constants =====
+constexpr uint16_t SERIAL_SETTLE_US = 500;       // Default serial settle time in microseconds
+constexpr uint8_t STARTUP_DELAY_MS = 100;        // Delay required at startup for Display/Shield settle?
+constexpr uint8_t ADDRESS_DATA_SETTLE_US = 5;    // Default latch settle time in microseconds
+constexpr uint8_t ROM_24PIN_WRITE_PULSE_MS = 50; // 24 Pin ROM write pulse duration in milliseconds
+constexpr uint8_t ROM_28PIN_WRITE_PULSE_US = 100;// 28 Pin ROM write pulse duration in microseconds
 
 // ===== EPROM Data Buffer & Address State =====
 constexpr uint8_t BUFFERSIZE = 128;              // Default buffersize
@@ -154,9 +161,9 @@ struct Command {                                 // Struct to hold the current c
 };
 Command currentCommand;                          // Instance of Command to store the current action being performed
 
-// the setup function runs once when you press reset or power the board
+// The setup function runs once when you press reset or power the board
 void setup() {
-    delay(100);                                 // Without this behaviour is inconsistent/problematic - either LCD or Shield related!
+    delay(STARTUP_DELAY_MS);                    // Without this behaviour is inconsistent/problematic - either LCD or Shield related!
     initial_pin_state();                        // Initialise port B, port D, address, VCC and VPP pin states
     
     // Initialize the OLED display
@@ -172,7 +179,7 @@ void setup() {
     display.display();
     
     Serial.begin(BAUDRATE);                     // Open serial port - Can't latch things when serial is enabled (begin)
-    delayMicroseconds(500);                     // Let serial settle
+    delayMicroseconds(SERIAL_SETTLE_US);        // Let serial settle
 }
 
 // Keep checking for data in the serial buffer, otherwise process button and display menu
@@ -206,7 +213,7 @@ void loop() {
 
             initial_pin_state();                    // Reinitialise port pin states
             Serial.begin(BAUDRATE);                 // Open serial port
-            delayMicroseconds(500);                 // Let serial settle
+            delayMicroseconds(SERIAL_SETTLE_US);    // Let serial settle
         } 
     } else {
         handleButton();
@@ -227,7 +234,7 @@ void loop() {
       }
     */
     }
-} //Loop
+} // Loop
 
 // Configure the initial arduino/rurp pin states
 void initial_pin_state() {
@@ -238,7 +245,7 @@ void initial_pin_state() {
     
     // Clear all values and latch
     PORTD = 0x00;                                           // Set all data/address pins to 0 (D0-D7 pins)
-    delayMicroseconds(5);                                   // Let Address/Data settle
+    delayMicroseconds(ADDRESS_DATA_SETTLE_US);              // Let Address/Data settle
     PORTB |= RLSBLE | RMSBLE | CTRL_LE;                     // Set RLSBLE, RMSBLE, CTRL_LE pin HIGH 
     PORTB &= ~(RLSBLE | RMSBLE | CTRL_LE);                  // Set RLSBLE, RMSBLE, CTRL_LE pin LOW to latch zero values
 
@@ -263,9 +270,15 @@ void dumpROM() {
     cAddr = (cAddrH << 8) | cAddrL;                         // Assemble 16-bit start address from MSB and LSB
     
     romSize = (static_cast<uint32_t>(Serial.read()) << 8);  // Reads stoppage a.k.a. the high byte of ROM size
-    if (romSize == 0) romSize = 65536;                      // Need a fix to support A17+
+    if (romSize == 0) romSize = MAX_ROM_SIZE_16BIT;         // Need a fix to support A17+
     romPinCount = Serial.read();                            // Read in the ROM Pin count
     
+    // Validate block size
+    if (currentCommand.blockSize > BUFFERSIZE) {
+        display.print(F("Error: Block size too large"));
+        return;
+    }
+
     Serial.end();                                           // Release shared pins
     
     if (romPinCount == 24) latchAddress(VCC24PIN << 8);     // Enable VCC for 24 pin ROM - shift to MSB
@@ -277,41 +290,57 @@ void dumpROM() {
     display.print(currentCommand.blockSize);
     display.display();
 
+    // Calculate totalBlocks, rounding up to ensure any remainder bytes get their own block
+    uint16_t totalBlocks = (romSize + currentCommand.blockSize - 1) / currentCommand.blockSize;
+
     // loop over the total number of blocks in the ROM
-    for (int i = 0; i < romSize/currentCommand.blockSize; i++) {
-        // Read data into buffer
-        for (uint16_t addr = 0; addr < currentCommand.blockSize; addr++) {
+    for (uint32_t blockNum = 0; blockNum < totalBlocks; blockNum++) {
+        // Calculate bytes to read in the final block
+        uint16_t bytesToRead = currentCommand.blockSize;
+        if (cAddr + bytesToRead > romSize) {
+            bytesToRead = romSize - cAddr;
+        }
+
+        // Read entire block
+        for (uint16_t addr = 0; addr < bytesToRead; addr++) {
             buffer[addr] = readAddress(cAddr);              // Read ROM data into buffer
             cAddr++;
         }
-
-        delayMicroseconds(500);                             // Avoid framing errors - value can be tuned depending on BAUDRATE
         Serial.begin(BAUDRATE);                             // Open serial port
-        
+        delayMicroseconds(SERIAL_SETTLE_US);                // Brief settle time to avoid framing errors
+
         Serial.write(0xAA);                                 // Transmit the frame start block indicator
-        
-        for (uint16_t addr = 0; addr < currentCommand.blockSize; addr++) {
-            Serial.write(buffer[addr]);  
-        }
-        
+        Serial.flush();                                     // Wait for start block transmission to complete
+     
+        Serial.write(buffer, bytesToRead);                  // Send entire buffer at once
+        Serial.flush();                                     // Wait for transmission to complete
+
         Serial.end();                                       // Release pins for next read cycle
     }
 }
 
 // Read serial data and burn to ROM
 void burnROM() {
+    bool dataProcessed = false;                      // initialise flag to indicate data has been processed
     byte controlByte = 0x00;                         // initialise control byte
+    static const byte EOF_BYTE = 0x00;               // define end of file as empty byte
     
     currentCommand.blockSize = Serial.read();        // read the blocksize
     currentCommand.stopPage = Serial.read();         // read the stop page - currently unused!
     romPinCount = Serial.read();                     // read the ROM pin count
     
+    // Validate block size
+    if (currentCommand.blockSize > BUFFERSIZE) {
+        display.print(F("Error: Block size too large"));
+        return;
+    }
+
     Serial.end();                                    // Release shared pins
     
     if (romPinCount == 24) {
         latchAddress(VCC24PIN << 8);                 // Enable 24 pin VCC - shift to MSB
-        controlByte = (REG_DISABLE | P1_VPP_ENABLE); // Enabling P1_VPP_Enable for JP4 (Leave OPEN for 28 pin ROMs!!))
         PORTB &= ~(ROM_CE);                          // Make sure chip is enabled
+        controlByte = (REG_DISABLE | P1_VPP_ENABLE); // Enabling P1_VPP_Enable for JP4 (Leave OPEN for 28 pin ROMs!!))
     }
 
     if (romPinCount == 28) {
@@ -326,13 +355,14 @@ void burnROM() {
     display.print(currentCommand.blockSize);
     display.display();
     
-    delay(200);
     Serial.begin(BAUDRATE);                          // Open serial port
+    delayMicroseconds(SERIAL_SETTLE_US);             // Let the serial come up and settle
 
     // Process each block of binary source file data via serial until no more bytes read
     while (1) { 
         Serial.write(0xAA);                          // Send ready signal
-        
+        Serial.flush();                              // Wait for 0xAA transmission to complete
+
         while (!Serial.available());                 // Wait for data to arrive in the serial receive buffer
         
         memset(buffer, 0xFF, BUFFERSIZE);            // Clear buffer with 0xFF
@@ -340,18 +370,29 @@ void burnROM() {
         // Read the block of data
         size_t bytesRead = Serial.readBytes((char *)buffer, currentCommand.blockSize);
         
-        // Check if we've read the entire block
-        if (bytesRead > 0 && bytesRead <= currentCommand.blockSize) {
-            // Process the buffer data
-            Serial.end();                            // Release shared pins
-            delayMicroseconds(20);                   // Let the serial settle
-            writefromBuffer(cAddr, currentCommand.blockSize);
-        } else {
-            display.println("Bad block");
+        // check for EOF_BYTE and data processing complete, zero length block, no data, bad block, otherwise process data block
+        if (bytesRead == 1 && buffer[0] == EOF_BYTE && dataProcessed) {
+            display.println(F("Transfer Complete"));
             break;
+        } else if (bytesRead == 1 && buffer[0] == 0x00 ) {
+            display.println(F("Error: Bad zero length block"));
+            break;
+        } else if (bytesRead == 0) {
+            display.println(F("Error: No data"));
+            break;
+        } else if (bytesRead > currentCommand.blockSize) {
+            display.println(F("Error: Bad block"));
+            break;      
+        } else {
+            Serial.end();                            // Release shared pins
+            delayMicroseconds(SERIAL_SETTLE_US);     // Let the serial settle
+
+            writefromBuffer(cAddr, bytesRead);
+            dataProcessed = true;                    // Set data processed indicator
+         
+            Serial.begin(BAUDRATE);                  // Open serial port back up
+            delayMicroseconds(SERIAL_SETTLE_US);     // Let the serial settle
         }
-        delayMicroseconds(20);
-        Serial.begin(BAUDRATE);                      // Open serial port back up
     }
 }
 
@@ -375,8 +416,7 @@ void eraseROM() {
 // Enable Regulator on the RURP shield
 void enableRegulator() {
     byte outputState = REG_DISABLE;  // Set REG_DISABLE bit
-    // Set all pins using direct port manipulation
-    latchControlByte(outputState);
+    latchControlByte(outputState);   // Set all pins using direct port manipulation
 }
 
 // Show VEP on oled display to facilitate manual adjustment
@@ -436,14 +476,14 @@ void writefromBuffer(uint16_t addr, uint16_t len) {
         
         if (romPinCount == 28) {
             PORTB &= ~(ROM_CE);                 // Low pulse sets up ROM write for 28pin chips
-            delayMicroseconds(101);
+            delay(ROM_28PIN_WRITE_PULSE_US);    // 100us pulse length performs the 28pin ROM write
             PORTB |= ROM_CE;                    // Return CE to high
         }
         if (romPinCount == 24) {
             PORTB |= ROM_CE;                    // High pulse allows ROM write for 2716/TMS2516
-            delay(50);                          // 50ms pulse length performs the 2716/TMS2516 ROM write
+            delay(ROM_24PIN_WRITE_PULSE_MS);    // 50ms pulse length performs the 2716/TMS2516 ROM write
             PORTB &= ~(ROM_CE);                 // Low pulse allows ROM write for all other 24pin chips, whilst ending 2716 pulse
-            delay(50);                          // 50ms pulse length performs all other 24pin ROM write
+            delay(ROM_24PIN_WRITE_PULSE_MS);    // 50ms pulse length performs all other 24pin ROM write
             PORTB |= ROM_CE;                    // End all other 24pin write pulse
             PORTB &= ~(ROM_CE);                 // Return Chip Enable low in readiness for next address to be written for 2716
         }
@@ -493,7 +533,7 @@ byte readAddress(uint16_t addr) {
     latchAddress(addr);                         // Set the address pins
     DDRD = 0x00;                                // Set all digital pins (0-7) as Input
     PORTB &= ~(ROM_OE | ROM_CE);                // Set pins Output Enable and Chip Enable LOW 
-    delayMicroseconds(20);                      // Let Address/Data settle 
+    delayMicroseconds(ADDRESS_DATA_SETTLE_US);  // Let Address/Data settle 
     byte val = PIND;                            // Read the value from all digital output pins
     PORTB |= (ROM_OE);                          // Set Output Enable HIGH, leave CE LOW
     return val;
@@ -501,11 +541,11 @@ byte readAddress(uint16_t addr) {
 
 // Push a 8-bit value onto the arduino D0-D7 pins and latch
 void latchControlByte(byte controlByte) {
-    if (romPinCount == 28) controlByte |= VCC28PIN; //Enable VCC for 28 pin ROMs
+    if (romPinCount == 28) controlByte |= VCC28PIN; // Enable VCC for 28 pin ROMs
   
     DDRD = 0xFF;                                    // Set all digital pins (0-7) as Output
     PORTD = controlByte;                            // Push the control value onto the pins
-  
+    delayMicroseconds(ADDRESS_DATA_SETTLE_US);      // Let Address/Data settle
     PORTB |= CTRL_LE;                               // Set CTRL_LE pin HIGH to latch
     PORTB &= ~(CTRL_LE);                            // Set CTRL_LE pin LOW to unlatch
 }
@@ -518,6 +558,7 @@ void latchAddress(uint16_t address) {
     // Check if LSB has changed
     if (lsb != prevLSB) {
         PORTD = lsb;                                // Write LSB address to PORTD pins
+        delayMicroseconds(ADDRESS_DATA_SETTLE_US);  // Let Address/Data settle
         PORTB |= RLSBLE;                            // Set RLSBLE pin HIGH to latch lower 8 bits of address (LSB)
         PORTB &= ~RLSBLE;                           // Set RLSBLE pin LOW to unlatch lower 8 bits of address (LSB)
         prevLSB = lsb;                              // Update prevLSB
@@ -531,6 +572,7 @@ void latchAddress(uint16_t address) {
             msb |= VCC24PIN;                        // Enable VCC on "A13"
         }
         PORTD = msb;                                // Write MSB address to PORTD pins
+        delayMicroseconds(ADDRESS_DATA_SETTLE_US);  // Let Address/Data settle
         PORTB |= RMSBLE;                            // Set RMSBLE pin HIGH to latch higher 8 bits of address (MSB)
         PORTB &= ~RMSBLE;                           // Set RMSBLE pin LOW to unlatch higher 8 bits of address (MSB)
     }
@@ -627,7 +669,7 @@ uint16_t blankCheck () {
     display.println(F("Checking if ROM is blank.."));
     display.display();
     uint32_t i;
-    for (i = 0; i < 65537; i++) {
+    for (i = 0; i < MAX_ROM_SIZE_16BIT; i++) {
         byte data = readAddress(i);
         if (data != 0xFF) {
             display.print(data,HEX);
@@ -637,6 +679,5 @@ uint16_t blankCheck () {
             return 1;               // Not blank
         } 
     }
-    if (i == 65537) i = 0;
-    return i;                       // blank
+    return 0;                       // blank
 }

--- a/software/Arduino/ArduinoProgrammerFirmwarePrototype/ArduinoProgrammerFirmwarePrototype.ino
+++ b/software/Arduino/ArduinoProgrammerFirmwarePrototype/ArduinoProgrammerFirmwarePrototype.ino
@@ -168,8 +168,7 @@ void setup() {
     
     // Initialize the OLED display
     if(!display.begin(SSD1306_SWITCHCAPVCC, 0x3C)) {
-        //latchControlByte(0x40);
-        for(;;);
+        while(1);                               // Critical failure - halt
     }
 
     display.clearDisplay();
@@ -178,7 +177,7 @@ void setup() {
     display.println("Boot complete.");
     display.display();
     
-    Serial.begin(BAUDRATE);                     // Open serial port - Can't latch things when serial is enabled (begin)
+    Serial.begin(BAUDRATE);                     // Open serial port - Can't latch things when serial is enabled
     delayMicroseconds(SERIAL_SETTLE_US);        // Let serial settle
 }
 
@@ -218,21 +217,6 @@ void loop() {
     } else {
         handleButton();
         displayMenu();
-    /*
-    if (digitalRead(12) == 0) {
-      Serial.end();
-      enableRegulator();
-      display.println("Press RST after calibrating VEP");
-      while (1) {
-            displayVEP();
-            delay(17);
-        }
-      } else {
-        display.print(".");
-        display.display();
-        delay(500);
-      }
-    */
     }
 } // Loop
 
@@ -435,29 +419,6 @@ void displayVEP() {
     display.print(v_vep, 2);                            // Display voltage with 2 decimal places
     display.println(" V");
     display.display();
-}
-
-//For single byte writes 
-void writeByte(uint16_t address, byte data) {
-    latchAddress(address);
-    byte controlbyte = 0;
-    if (romPinCount == 24) {
-        controlbyte = (REG_DISABLE | P1_VPP_ENABLE); //Enabling P1_VPP_Enable for JP4 (Leave OPEN for 28 pin ROMs!!))
-    }
-    if (romPinCount == 28) {
-        controlbyte = (VPE_TO_VPP | REG_DISABLE | VPE_ENABLE | VCC28PIN);
-    }
-    
-    latchControlByte((VPE_TO_VPP | REG_DISABLE) & controlbyte);
-    delay(50); //Settle before enabling
-    latchControlByte(controlbyte );
-    //delay(255); //What works on 65uino
-    DDRD = 0xFF; //Output
-    PORTD = data; 
-    PORTB &= ~(ROM_CE);
-    delayMicroseconds(101);
-    PORTB |= ROM_CE;
-    latchControlByte(0x00); 
 }
 
 // Perform data write to selected ROM for the current address parameter

--- a/software/Arduino/ArduinoProgrammerFirmwarePrototype/ArduinoProgrammerFirmwarePrototype.ino
+++ b/software/Arduino/ArduinoProgrammerFirmwarePrototype/ArduinoProgrammerFirmwarePrototype.ino
@@ -142,6 +142,11 @@ byte prevMSB = 0xFF;                             // Previous MSB latchaddress st
 // ===== Serial Communication =====
 constexpr uint32_t BAUDRATE = 19200;             // Default device BAUDRATE
 
+// ===== Command Byte Actions =====
+constexpr byte CMD_MODE = 0xAA;                  // Command mode flag
+constexpr byte CMD_DUMP = 0x01;                  // Command - Dump ROM to serial
+constexpr byte CMD_BURN = 0x02;                  // Command - Burn ROM from serial
+constexpr byte CMD_ERASE = 0x03;                 // Command - Erase ROM
 struct Command {                                 // Struct to hold the current command, block size, and stop page
     uint8_t command;
     uint8_t blockSize;
@@ -151,148 +156,57 @@ Command currentCommand;                          // Instance of Command to store
 
 // the setup function runs once when you press reset or power the board
 void setup() {
-    // Set pins D0-D7 as outputs
-    DDRD = 0xFF; // Set all D0-D7 pins as outputs
-    // Set control signals as outputs
-    DDRB |= RLSBLE | RMSBLE | ROM_OE | CTRL_LE | ROM_CE;
-  
-    // Set all pins using direct port manipulation
-    PORTD = 0;
+    delay(100);                                 // Without this behaviour is inconsistent/problematic - either LCD or Shield related!
+    initial_pin_state();                        // Initialise port B, port D, address, VCC and VPP pin states
     
-    // Set all latch pins HIGH using direct port manipulation and disable ROM 
-    PORTB |= RLSBLE | RMSBLE | ROM_OE | CTRL_LE | ROM_CE | USRBTN;
-    delayMicroseconds(1);
-    // Set all latch pins LOW using direct port manipulation
-    PORTB &= ~(RLSBLE | RMSBLE | CTRL_LE); // Set pins D8, D9, D11 low
-  
     // Initialize the OLED display
     if(!display.begin(SSD1306_SWITCHCAPVCC, 0x3C)) {
-        //  latchControlByte(0x40);
+        //latchControlByte(0x40);
         for(;;);
     }
-    
-    delay(100);                                 // Without this behaviour is inconsistent/problematic - either LCD or Shield related!
-   
-    // Clear the display
+
     display.clearDisplay();
     display.setTextSize(1);
     display.setTextColor(SSD1306_WHITE);
     display.println("Boot complete.");
     display.display();
-    readAddress(0); //Init address latch
-    latchControlByte(VCC28PIN|P1_VPP_ENABLE); //Can't latch things when serial is enabled
-    delay(1); //Avoid serial framing error
+    
     Serial.begin(BAUDRATE);                     // Open serial port - Can't latch things when serial is enabled (begin)
+    delayMicroseconds(500);                     // Let serial settle
 }
 
 // Keep checking for data in the serial buffer, otherwise process button and display menu
 void loop() {
     if (Serial.available()) {
         byte incomingByte = Serial.read();          // Read first byte from the serial receive buffer
-        if (incomingByte == 0xAA ) {            // Check for incoming Command Mode byte
-            while (!Serial.available()) { 
-                ;; //Maybe we don't need it
-            }
+
+        if (incomingByte == CMD_MODE ) {            // Check for incoming Command Mode byte
+            while (!Serial.available());            // Wait for more data to arrive in the serial receive buffer
+            
             currentCommand.command = Serial.read(); // Read from buffer current command 
-      
-            if (currentCommand.command == 0x01) {       // Process selected command
-                //Dump ROM via serial
-                currentCommand.blockSize = Serial.read();               // Read in the blocksize
-                byte cAddrL = Serial.read();                            // Read start address LSB
-                byte cAddrH = Serial.read();                            // Read start address MSB
-                cAddr = (cAddrH << 8) | cAddrL;                         // Assemble 16-bit start address from MSB and LSB
-                
-                romSize = (static_cast<uint32_t>(Serial.read()) << 8);  //Reads stoppage a.k.a. the high byte of ROM size
-                if (romSize == 0) romSize = 65536;                      // Need a fix to support A17+
-                romPinCount = Serial.read();                            // Read in the ROM Pin count
-                Serial.end();                                           // Release shared pins
-                if (romPinCount == 24) latchAddress(VCC24PIN << 8);     // Enable VCC for 24 pin ROM - shift to MSB
-                if (romPinCount == 28) latchControlByte(VCC28PIN);      // Enable VCC for 28 pin ROM
-                display.clearDisplay();
-                display.print(F("Sending ROM via serial..."));
-                display.print("Blocksize: ");
-                display.print(currentCommand.blockSize);
-                display.display();
-                // loop over the total number of blocks in the ROM
-                for (int i = 0; i < romSize/currentCommand.blockSize; i++) {
-                    // Read data into buffer
-                    for (uint16_t addr = 0; addr < currentCommand.blockSize; addr++) {
-                        buffer[addr] = readAddress(cAddr);              // Read ROM data into buffer
-                        cAddr++;
-                    }
-                    delayMicroseconds(500); //Avoid framing errors - value can be tuned depending on BAUDRATE
-                    Serial.begin(BAUDRATE);                             // Open serial port
-                    Serial.write(0xAA);                                 // Transmit the frame start block indicator
-                    for (uint16_t addr = 0; addr < currentCommand.blockSize; addr++) {
-                        Serial.write(buffer[addr]);  
-                    }
-                    Serial.end();                                       // Release pins for next read cycle
-                }
+
+            switch (currentCommand.command) {       // Process selected command
+                case CMD_DUMP:                      
+                    dumpROM();
+                    break;
+                case CMD_BURN:
+                    burnROM();
+                    break;
+                case CMD_ERASE:
+                    eraseROM();
+                    break;
+                default:
+                    display.clearDisplay();
+                    display.print(F("Unknown Command"));
+                    break;
             }
-      
-            if (currentCommand.command == 0x03) {
-                byte vendor = Serial.read();
-                byte device = Serial.read();
-                uint16_t romid = (static_cast<uint16_t>(vendor) << 8) | device;
-                Serial.end();                                   // Release shared UART pins
-                display.clearDisplay();
-                display.println(F("Erasing ROM with ID: "));
-                display.println(romid, HEX);
-                display.display();
-                eraseW27C512(romid);
-                delay(3000);
-            }
-      
-            if (currentCommand.command == 0x02) { 
-                byte controlByte = 0x00;                         // initialise control byte
-                prevLSB = 0xFF;
-                prevMSB = 0xFF;
-                cAddr = 0;
-                //Burn ROM from serial
-                currentCommand.blockSize = Serial.read();        // read the blocksize
-                currentCommand.stopPage = Serial.read();         // read the stop page - currently unused!
-                romPinCount = Serial.read();                     // read the ROM pin count
-                Serial.end();                                    // Release shared pins
-                if (romPinCount == 24) {
-                    latchAddress(VCC24PIN << 8);                 // Enable 24 pin VCC - shift to MSB
-                    controlByte = (REG_DISABLE | P1_VPP_ENABLE); // Enabling P1_VPP_Enable for JP4 (Leave OPEN for 28 pin ROMs!!))
-                    PORTB &= ~(ROM_CE);                          // Make sure chip is enabled
-                }
-                if (romPinCount == 28) {
-                    controlByte = (VPE_TO_VPP | REG_DISABLE | VPE_ENABLE | VCC28PIN);
-                }
-        
-                display.clearDisplay();
-                display.println(F("Burning ROM from serial..."));
-                display.print("Blocksize: ");
-                display.print(currentCommand.blockSize);
-                display.display();
-                latchControlByte(controlByte);                   // Apply ROM control pin configuration
-                delay(200);
-                Serial.begin(BAUDRATE);                          // Open serial port
-                // Process each block of binary source file data via serial until no more bytes read
-                while (1) { 
-                    Serial.write(0xAA);                          // Send ready signal
-                    while (!Serial.available()) {                // Wait for data to arrive in the serial receive buffer
-                        ;; //Maybe we don't need it
-                    }
-                    memset(buffer, 0xFF, BUFFERSIZE);            // Clear buffer with 0xFF
-                    // Read the block of data
-                    size_t bytesRead = Serial.readBytes((char *)buffer, currentCommand.blockSize);
-                    // Check if we've read the entire block
-                    if (bytesRead > 0 && bytesRead <= currentCommand.blockSize) {
-                        // Process the buffer data
-                        Serial.end();                            // Release shared pins
-                        delayMicroseconds(20);                   // Let the serial settle
-                        writefromBuffer(cAddr, currentCommand.blockSize);
-                    } else {
-                        display.println("Bad block");
-                        break;
-                    }
-                    delayMicroseconds(20);
-                    Serial.begin(BAUDRATE);                      // Open serial port back up
-                }
-            }
+            
+            Serial.flush();                         // Wait for any prior transmission to complete
+            Serial.end();                           // Release shared UART pins
+
+            initial_pin_state();                    // Reinitialise port pin states
+            Serial.begin(BAUDRATE);                 // Open serial port
+            delayMicroseconds(500);                 // Let serial settle
         } 
     } else {
         handleButton();
@@ -312,8 +226,151 @@ void loop() {
         delay(500);
       }
     */
-    } //Serial 0xAA
+    }
 } //Loop
+
+// Configure the initial arduino/rurp pin states
+void initial_pin_state() {
+    // Set digital pin input/output direction
+    DDRD = 0xFF;                                            // Initialise all data/address pins as outputs (D0-D7 pins)
+    DDRB = 0x00;                                            // Initialise all digital pins D8-D13 as inputs
+    DDRB |= RLSBLE | RMSBLE | ROM_OE | CTRL_LE | ROM_CE;    // Set specific digital pins as outputs
+    
+    // Clear all values and latch
+    PORTD = 0x00;                                           // Set all data/address pins to 0 (D0-D7 pins)
+    delayMicroseconds(5);                                   // Let Address/Data settle
+    PORTB |= RLSBLE | RMSBLE | CTRL_LE;                     // Set RLSBLE, RMSBLE, CTRL_LE pin HIGH 
+    PORTB &= ~(RLSBLE | RMSBLE | CTRL_LE);                  // Set RLSBLE, RMSBLE, CTRL_LE pin LOW to latch zero values
+
+    // Set ROM defaults
+    PORTB |= ROM_OE | ROM_CE;                               // Initialise Output Enabled, Chip Enable, User button pins to HIGH
+    romPinCount = ROM_PIN_COUNT;                            // Default rom pin count
+    romSize = ROM_SIZE;                                     // We need to support more than 16 address bits
+
+    PORTB |= USRBTN;                                        // Set internal pull-up resistor for USRBTN
+
+    // Clear address state tracking
+    prevLSB = 0xFF;                                         // Reset Previous LSB latchAddress() state tracking 
+    prevMSB = 0xFF;                                         // Reset Previous MSB latchAddress() state tracking 
+    cAddr = 0;                                              // Reset current address state tracking
+}
+
+// Read ROM data and dump over serial
+void dumpROM() {
+    currentCommand.blockSize = Serial.read();               // Read in the blocksize
+    byte cAddrL = Serial.read();                            // Read start address LSB
+    byte cAddrH = Serial.read();                            // Read start address MSB
+    cAddr = (cAddrH << 8) | cAddrL;                         // Assemble 16-bit start address from MSB and LSB
+    
+    romSize = (static_cast<uint32_t>(Serial.read()) << 8);  // Reads stoppage a.k.a. the high byte of ROM size
+    if (romSize == 0) romSize = 65536;                      // Need a fix to support A17+
+    romPinCount = Serial.read();                            // Read in the ROM Pin count
+    
+    Serial.end();                                           // Release shared pins
+    
+    if (romPinCount == 24) latchAddress(VCC24PIN << 8);     // Enable VCC for 24 pin ROM - shift to MSB
+    if (romPinCount == 28) latchControlByte(VCC28PIN);      // Enable VCC for 28 pin ROM
+    
+    display.clearDisplay();
+    display.print(F("Sending ROM via serial..."));
+    display.print("Blocksize: ");
+    display.print(currentCommand.blockSize);
+    display.display();
+
+    // loop over the total number of blocks in the ROM
+    for (int i = 0; i < romSize/currentCommand.blockSize; i++) {
+        // Read data into buffer
+        for (uint16_t addr = 0; addr < currentCommand.blockSize; addr++) {
+            buffer[addr] = readAddress(cAddr);              // Read ROM data into buffer
+            cAddr++;
+        }
+
+        delayMicroseconds(500);                             // Avoid framing errors - value can be tuned depending on BAUDRATE
+        Serial.begin(BAUDRATE);                             // Open serial port
+        
+        Serial.write(0xAA);                                 // Transmit the frame start block indicator
+        
+        for (uint16_t addr = 0; addr < currentCommand.blockSize; addr++) {
+            Serial.write(buffer[addr]);  
+        }
+        
+        Serial.end();                                       // Release pins for next read cycle
+    }
+}
+
+// Read serial data and burn to ROM
+void burnROM() {
+    byte controlByte = 0x00;                         // initialise control byte
+    
+    currentCommand.blockSize = Serial.read();        // read the blocksize
+    currentCommand.stopPage = Serial.read();         // read the stop page - currently unused!
+    romPinCount = Serial.read();                     // read the ROM pin count
+    
+    Serial.end();                                    // Release shared pins
+    
+    if (romPinCount == 24) {
+        latchAddress(VCC24PIN << 8);                 // Enable 24 pin VCC - shift to MSB
+        controlByte = (REG_DISABLE | P1_VPP_ENABLE); // Enabling P1_VPP_Enable for JP4 (Leave OPEN for 28 pin ROMs!!))
+        PORTB &= ~(ROM_CE);                          // Make sure chip is enabled
+    }
+
+    if (romPinCount == 28) {
+        controlByte = (VPE_TO_VPP | REG_DISABLE | VPE_ENABLE | VCC28PIN);
+    }
+
+    latchControlByte(controlByte);                   // Apply ROM control pin configuration
+
+    display.clearDisplay();
+    display.println(F("Burning ROM from serial..."));
+    display.print("Blocksize: ");
+    display.print(currentCommand.blockSize);
+    display.display();
+    
+    delay(200);
+    Serial.begin(BAUDRATE);                          // Open serial port
+
+    // Process each block of binary source file data via serial until no more bytes read
+    while (1) { 
+        Serial.write(0xAA);                          // Send ready signal
+        
+        while (!Serial.available());                 // Wait for data to arrive in the serial receive buffer
+        
+        memset(buffer, 0xFF, BUFFERSIZE);            // Clear buffer with 0xFF
+        
+        // Read the block of data
+        size_t bytesRead = Serial.readBytes((char *)buffer, currentCommand.blockSize);
+        
+        // Check if we've read the entire block
+        if (bytesRead > 0 && bytesRead <= currentCommand.blockSize) {
+            // Process the buffer data
+            Serial.end();                            // Release shared pins
+            delayMicroseconds(20);                   // Let the serial settle
+            writefromBuffer(cAddr, currentCommand.blockSize);
+        } else {
+            display.println("Bad block");
+            break;
+        }
+        delayMicroseconds(20);
+        Serial.begin(BAUDRATE);                      // Open serial port back up
+    }
+}
+
+// erase ROM data
+void eraseROM() {
+    byte vendor = Serial.read();
+    byte device = Serial.read();
+    uint16_t romid = (static_cast<uint16_t>(vendor) << 8) | device;
+
+    Serial.end();                                   // Release shared UART pins
+
+    display.clearDisplay();
+    display.println(F("Erasing ROM with ID: "));
+    display.println(romid, HEX);
+    display.display();
+
+    eraseW27C512(romid);
+    delay(3000);
+}
 
 // Enable Regulator on the RURP shield
 void enableRegulator() {

--- a/software/Arduino/ArduinoProgrammerFirmwarePrototype/ArduinoProgrammerFirmwarePrototype.ino
+++ b/software/Arduino/ArduinoProgrammerFirmwarePrototype/ArduinoProgrammerFirmwarePrototype.ino
@@ -1,506 +1,585 @@
 /*
- Written by Anders Nielsen, 2024
- https://abnielsen.com/65uino
- Some GPL license
+ --------------------------------------------------------------------------------------------------
+  Project:    Relatively-Universal-ROM-Programmer (RURP)
+  File:       ArduinoProgrammerFirmwarePrototype.ino
+  Target:     Arduino Uno (ATmega328P)
+  License:    GNU GPL v3.0 (as per original project)
+  
+  Original Author:
+      Anders Nielsen (2024)
+      https://abnielsen.com/65uino
+      GPL-3.0 License
+
+  Modified By:
+      BizarroBull (2024)
+        • cast result of Serial.read() so it doesn't get treated as signed when bit shifting
+
+      TheSubWayKing (2025)
+        • Expanded and improved 2716 EPROM read/write support
+        • Added improved error handling and input validation
+        • Refactored for coding-standard consistency
+        • Improved I/O configuration logic and bus-direction control
+        • Added safer timing behavior and cleaner command parsing
+        • Updated documentation and code comments
+
+ --------------------------------------------------------------------------------------------------
+  Hardware Context:
+      This firmware is written for the “Relatively Universal ROM Programmer”
+      (RURP) shield designed by Anders Nielsen for the Arduino Uno.  
+      
+      The RURP shield supports a broad variety of parallel ROM/EPROM/EEPROM
+      devices through a flexible address/data bus, latch bank, and mode
+      control lines (OE, CE, WE). The 2716 EPROM, being one of the earliest
+      EPROM types with unique timing and power-enable constraints, requires
+      specific handling not fully addressed by alternative RURP firmware.
+
+      Another community firmware (“Firestarter”) provides more comprehensive
+      device-family support overall, but **does not currently support the 2716**.
+      This modified firmware exists to fill that gap and to modernize the
+      original 2716-focused codebase.
+
+ --------------------------------------------------------------------------------------------------
+  Sketch Overview / Functional Description:
+      This sketch implements a full command-driven serial interface for ROM
+      programming, reading, verification, and memory utilities specifically
+      tuned for the 2716 EPROM. Major features include:
+
+        • Full 2716 read cycle implementation using correct OE/CE timing
+        • Write/Program pulse generation with adjustable microsecond timing
+        • Data-bus tri-state management for read/write transitions
+        • Address-bus and control-line mapping via AVR ports:
+              - PORTD / DDRD for address/data bus (D0–D7)
+              - PORTB / DDRB for control latches (D8-D13)
+        • Error handling for invalid commands, timing violations,
+          serial framing issues, and out-of-range accesses
+        • Buffered read operations and configurable dump size
+        • Command set for:
+              - Reading EPROM into buffer
+              - Writing buffer contents to EPROM
+              - Blank-check
+              - Verification
+              - Direct byte I/O for debugging
+              - Diagnostic and version reporting
+
+ --------------------------------------------------------------------------------------------------
+  Revision History:
+      2024-05-15 – Initial Arduino Firmware Prototype (AndersBNielsen)
+      2024-05-17 - Arduino sketch now successfully reads a ROM to serial.. Slowly. (AndersBNielsen)
+      2024-05-20 - Untested code for writing to W27C512 via serial (AndersBNielsen)
+      2024-05-21 - Erasing and programming a W27C512 (AndersBNielsen)
+      2024-05-22 - Erasing, Burning, and Reading a W27C512 now works! (AndersBNielsen)
+      2024-05-24 - Added selection menu to Arduino sketch (AndersBNielsen)
+      2024-05-24 - Arduino sketch enters calibration with a buttonpress (AndersBNielsen)
+      2024-08-01 - Update ArduinoProgrammerFirmwarePrototype.ino (BizarroBull)
+      2025-08-17 - 2716 / TMS2532 support (AndersBNielsen)
+      2025-11-19 – Major enhancements and 2716-specific improvements (TheSubWayKing)
+ --------------------------------------------------------------------------------------------------
 */
 
 #include <Wire.h>
 #include <Adafruit_GFX.h>
 #include <Adafruit_SSD1306.h>
 
-#define SCREEN_WIDTH 128
-#define SCREEN_HEIGHT 64
+// ===== Monochrome OLED Display =====
+constexpr uint8_t SCREEN_WIDTH = 128;            // OLED width
+constexpr uint8_t SCREEN_HEIGHT = 64;            // OLED height
+constexpr int8_t OLED_RESET = -1;                // Reset pin # (or -1 if sharing Arduino reset pin)
 
-#define OLED_RESET -1 // Reset pin # (or -1 if sharing Arduino reset pin)
 Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RESET);
 
-#define LONG_PRESS_TIME 1000  // Long press threshold in milliseconds
-
-int menuIndex = 0;
-unsigned long buttonPressTime = 0;
-bool buttonPressed = false;
-
-const char* menuItems[] = {"Calibrate VEP", "Display ROM ID", "Blank check ROM", "Erase W27C512"};
-const int menuItemsCount = sizeof(menuItems) / sizeof(menuItems[0]);
-
-const float R1 = 270.0;   // Resistance R1 in kohms
-const float R2 = 44.0;  // Resistance R2 in kohms
-const float V_REF = 5.06; // Reference voltage in volts
-const int ANALOG_PIN = A2; // Analog pin connected to VEP
-
-#define RLSBLE  0x01
-#define RMSBLE  0x02
-#define ROM_OE  0x04
-#define CTRL_LE 0x08
-#define USRBTN  0x10
-#define ROM_CE  0x20
-
-#define VPE_TO_VPP    0b00000001
-#define A9_VPP_ENABLE 0b00000010
-#define VPE_ENABLE    0b00000100
-#define P1_VPP_ENABLE 0b00001000
-#define A17_E         0b00010000
-#define VCC28PIN      0b00010000
-#define A18_E         0b00100000
-#define RW            0b01000000
-#define REG_DISABLE   0b10000000
-
-uint32_t romsize = 4096; //We need to support more than 16 address bits
-byte pattern = 0xAA;
-// Global variables to store the previous LSB and MSB values
-byte prevLSB = 0xFF;
-byte prevMSB = 0xFF;
-uint16_t cAddr = 0;
-#define BUFFERSIZE 128
-byte buffer[BUFFERSIZE]; 
-
-byte rompincount = 28; 
-
-uint32_t baudrate = 19200;
-
-// Define a struct to hold the command, block size, and stop page
-struct Command {
-  uint8_t command;
-  uint8_t blockSize;
-  uint8_t stopPage;
+// ===== Menu Items and User Input =====
+constexpr char* const MENU_ITEMS[] = {           // Menu item options 
+    "Calibrate VEP",
+    "Display ROM ID",
+    "Blank check ROM",
+    "Erase W27C512"
 };
+constexpr uint8_t MENU_ITEM_COUNT = sizeof(MENU_ITEMS) / sizeof(MENU_ITEMS[0]);
+constexpr uint16_t LONG_PRESS_TIME = 1000;       // Long press threshold in milliseconds
+uint8_t menuIndex = 0;                           // Track USR button press menu selection 
+unsigned long buttonPressTime = 0;               // Track USR button press duration
+bool buttonPressed = false;                      // Track USR button pressed
 
-Command currentCommand;
+// ===== Analog Voltage Monitoring (VPP/VEP) =====
+constexpr float R1 = 270.0;                      // Resistance R1 in kohms
+constexpr float R2 = 44.0;                       // Resistance R2 in kohms
+constexpr float V_REF = 5.06;                    // Reference voltage in volts
+constexpr uint8_t ANALOG_PIN = A2;               // Analog pin connected to VEP
+
+// ===== Hardware Control Pins (PORTB bitmasks) =====
+constexpr uint8_t RLSBLE  = 0b00000001;          // D8  – Latch Low-byte (A0-A7) when HIGH
+constexpr uint8_t RMSBLE  = 0b00000010;          // D9  – Latch High-byte (A8-A15) when HIGH
+constexpr uint8_t ROM_OE  = 0b00000100;          // D10 – Output Enable (active LOW)
+constexpr uint8_t CTRL_LE = 0b00001000;          // D11 – Control Latch Enable (active HIGH)
+constexpr uint8_t USRBTN  = 0b00010000;          // D12 – User button input
+constexpr uint8_t ROM_CE  = 0b00100000;          // D13 – Chip Enable (active LOW)
+
+// ===== EPROM Control Pins (PORTD bitmasks) =====
+constexpr uint8_t VPE_TO_VPP    = 0b00000001;    // Route VPE line to VPP voltage source
+constexpr uint8_t A9_VPP_ENABLE = 0b00000010;    // Enable VPP (programming voltage) on address line A9
+constexpr uint8_t VPE_ENABLE    = 0b00000100;    // Enable programming voltage on VPE pin
+constexpr uint8_t P1_VPP_ENABLE = 0b00001000;    // Enable VPP on pin P1 (or socket position 1)
+constexpr uint8_t A17_E         = 0b00010000;    // Enable high-order address line A17
+constexpr uint8_t VCC28PIN      = 0b00010000;    // (Alias) Select 28-pin device VCC mapping (shares bit with A17_E)
+constexpr uint8_t A18_E         = 0b00100000;    // Enable high-order address line A18
+constexpr uint8_t VCC24PIN      = 0b00100000;    // (Alias) Select 24-pin device VCC mapping (shares bit with A18_E)
+constexpr uint8_t RW            = 0b01000000;    // Read/Write control bit (1 = read, 0 = write) - (currently unused))
+constexpr uint8_t REG_DISABLE   = 0b10000000;    // Disable regulator
+
+// ===== EPROM Chip Parameters =====
+constexpr uint8_t ROM_PIN_COUNT = 28;            // Default ROM pin count
+constexpr uint32_t ROM_SIZE = 4096;              // Default ROM size
+uint8_t romPinCount = ROM_PIN_COUNT;             // ROM pin count
+uint32_t romSize = ROM_SIZE;                     // ROM size - We need to support more than 16 address bits
+
+// ===== EPROM Data Buffer & Address State =====
+constexpr uint8_t BUFFERSIZE = 128;              // Default buffersize
+byte buffer[BUFFERSIZE];                         // Contains the data being processed to and from EPROM
+uint16_t cAddr = 0;                              // Current address being processed
+byte prevLSB = 0xFF;                             // Previous LSB latchaddress state tracking
+byte prevMSB = 0xFF;                             // Previous MSB latchaddress state tracking
+
+// ===== Serial Communication =====
+constexpr uint32_t BAUDRATE = 19200;             // Default device BAUDRATE
+
+struct Command {                                 // Struct to hold the current command, block size, and stop page
+    uint8_t command;
+    uint8_t blockSize;
+    uint8_t stopPage;
+};
+Command currentCommand;                          // Instance of Command to store the current action being performed
 
 // the setup function runs once when you press reset or power the board
 void setup() {
-  // Set pins D0-D7 as outputs
-  DDRD = 0xFF; // Set all D0-D7 pins as outputs
-  // Set control signals as outputs
-  DDRB |= RLSBLE | RMSBLE | ROM_OE | CTRL_LE | ROM_CE;
-
-  // Set all pins using direct port manipulation
-  PORTD = 0;
+    // Set pins D0-D7 as outputs
+    DDRD = 0xFF; // Set all D0-D7 pins as outputs
+    // Set control signals as outputs
+    DDRB |= RLSBLE | RMSBLE | ROM_OE | CTRL_LE | ROM_CE;
   
-  // Set all latch pins HIGH using direct port manipulation and disable ROM 
-  PORTB |= RLSBLE | RMSBLE | ROM_OE | CTRL_LE | ROM_CE | USRBTN;
-delayMicroseconds(1);
-  // Set all latch pins LOW using direct port manipulation
-  PORTB &= ~(RLSBLE | RMSBLE | CTRL_LE); // Set pins D8, D9, D11 low
-
+    // Set all pins using direct port manipulation
+    PORTD = 0;
+    
+    // Set all latch pins HIGH using direct port manipulation and disable ROM 
+    PORTB |= RLSBLE | RMSBLE | ROM_OE | CTRL_LE | ROM_CE | USRBTN;
+    delayMicroseconds(1);
+    // Set all latch pins LOW using direct port manipulation
+    PORTB &= ~(RLSBLE | RMSBLE | CTRL_LE); // Set pins D8, D9, D11 low
+  
     // Initialize the OLED display
-  if(!display.begin(SSD1306_SWITCHCAPVCC, 0x3C)) {
-  //  latchControlByte(0x40);
-    for(;;);
-  }
-  
-  delay(100); // Pause for 2 seconds
-
-  // Clear the display
-  display.clearDisplay();
-  display.setTextSize(1);
-  display.setTextColor(SSD1306_WHITE);
-  display.println("Boot complete.");
-  display.display();
-  readAddress(0); //Init address latch
-  latchControlByte(VCC28PIN|P1_VPP_ENABLE); //Can't latch things when serial is enabled
-  delay(1); //Avoid serial framing error
-  Serial.begin(baudrate);
-
+    if(!display.begin(SSD1306_SWITCHCAPVCC, 0x3C)) {
+        //  latchControlByte(0x40);
+        for(;;);
+    }
+    
+    delay(100);                                 // Without this behaviour is inconsistent/problematic - either LCD or Shield related!
+   
+    // Clear the display
+    display.clearDisplay();
+    display.setTextSize(1);
+    display.setTextColor(SSD1306_WHITE);
+    display.println("Boot complete.");
+    display.display();
+    readAddress(0); //Init address latch
+    latchControlByte(VCC28PIN|P1_VPP_ENABLE); //Can't latch things when serial is enabled
+    delay(1); //Avoid serial framing error
+    Serial.begin(BAUDRATE);                     // Open serial port - Can't latch things when serial is enabled (begin)
 }
 
+// Keep checking for data in the serial buffer, otherwise process button and display menu
 void loop() {
-  if (Serial.available()) {
-    byte incomingByte = Serial.read();
-    if (incomingByte == 0xAA ) {
-      while (!Serial.available()) { 
-        ;; //Maybe we don't need it
-      }
-      currentCommand.command = Serial.read(); 
-
-      if (currentCommand.command == 0x01) {
-        //Dump ROM via serial
-        currentCommand.blockSize = Serial.read();
-        byte cAddrL = Serial.read();
-        byte cAddrH = Serial.read();
-        cAddr = cAddrH << 8;
-        cAddr |= cAddrL;
-        romsize = (static_cast<uint32_t>(Serial.read()) << 8); //Reads stoppage a.k.a. the high byte of ROM size
-        if (romsize == 0) romsize = 65536; //Need a fix to support A17+
-        rompincount = Serial.read();
-        Serial.end();
-        if (rompincount == 24) latchAddress(0x2000); //Enable VCC
-        if (rompincount == 28) latchControlByte(VCC28PIN);
-        display.clearDisplay();
-        display.print(F("Sending ROM via serial..."));
-        display.print("Blocksize: ");
-        display.print(currentCommand.blockSize);
-        display.display();
-        for (int i = 0; i < romsize/currentCommand.blockSize; i++) {
-        // Read data into buffer
-        for (uint16_t addr = 0; addr < currentCommand.blockSize; addr++) {
-          buffer[addr] = readAddress(cAddr);
-          cAddr++;
-        }
-        delayMicroseconds(500); //Avoid framing errors - value can be tuned depending on baudrate
-        Serial.begin(baudrate);
-        Serial.write(0xAA);
-        for (uint16_t addr = 0; addr < currentCommand.blockSize; addr++) {
-          Serial.write(buffer[addr]);  
-        }
-        Serial.end();
-        }
-      }
-
-      if (currentCommand.command == 0x03) {
-        byte vendor = Serial.read();
-        byte device = Serial.read();
-        uint16_t romid = (static_cast<uint16_t>(vendor) << 8) | device;
-        Serial.end();
-        display.clearDisplay();
-        display.println(F("Erasing ROM with ID: "));
-        display.println(romid, HEX);
-        display.display();
-        eraseW27C512(romid);
-        delay(3000);
-      }
-
-      if (currentCommand.command == 0x02) { 
-        byte controlbyte = 0;
-        prevLSB = 0xFF;
-        prevMSB = 0xFF;
-        cAddr = 0;
-        //Burn ROM from serial
-        currentCommand.blockSize = Serial.read();
-        currentCommand.stopPage = Serial.read();
-        rompincount = Serial.read();
-        Serial.end();
-        if (rompincount == 24) {
-        latchAddress(0x2000); //Enable VCC
-        controlbyte = (REG_DISABLE | P1_VPP_ENABLE); //Enabling P1_VPP_Enable for JP4 (Leave OPEN for 28 pin ROMs!!))
-        PORTB &= ~(ROM_CE); //Make sure chip is enabled
-        }
-        if (rompincount == 28) {
-          controlbyte = (VPE_TO_VPP | REG_DISABLE | VPE_ENABLE | VCC28PIN);
-        }
-
-        display.clearDisplay();
-        display.println(F("Burning ROM from serial..."));
-        display.print("Blocksize: ");
-        display.print(currentCommand.blockSize);
-        display.display();
-        latchControlByte(controlbyte); //Burn ROM config
-        delay(200);
-        Serial.begin(baudrate);
-        while (1) { 
-          Serial.write(0xAA);
-          while (!Serial.available()) { 
-          ;; //Maybe we don't need it
-           }
-          memset(buffer, 0xFF, BUFFERSIZE);            // Clear buffer with 0xFF
-          // Read the block of data
-          size_t bytesRead = Serial.readBytes((char *)buffer, currentCommand.blockSize);
-            // Check if we've read the entire block
-          if (bytesRead > 0 && bytesRead <= currentCommand.blockSize) {
-            // Process the buffer data
-           Serial.end();
-           delayMicroseconds(20);
-           writefromBuffer(cAddr, currentCommand.blockSize);
-          } else {
-            display.println("Bad block");
-            break;
-          }
-          delayMicroseconds(20);
-          Serial.begin(baudrate);
-          }
-      }
-    } 
-  } else {
-    handleButton();
-    displayMenu();
-  /*
-  if (digitalRead(12) == 0) {
-    Serial.end();
-    enableRegulator();
-    display.println("Press RST after calibrating VEP");
-    while (1) {
-          displayVEP();
-          delay(17);
-      }
+    if (Serial.available()) {
+        byte incomingByte = Serial.read();          // Read first byte from the serial receive buffer
+        if (incomingByte == 0xAA ) {            // Check for incoming Command Mode byte
+            while (!Serial.available()) { 
+                ;; //Maybe we don't need it
+            }
+            currentCommand.command = Serial.read(); // Read from buffer current command 
+      
+            if (currentCommand.command == 0x01) {       // Process selected command
+                //Dump ROM via serial
+                currentCommand.blockSize = Serial.read();               // Read in the blocksize
+                byte cAddrL = Serial.read();                            // Read start address LSB
+                byte cAddrH = Serial.read();                            // Read start address MSB
+                cAddr = (cAddrH << 8) | cAddrL;                         // Assemble 16-bit start address from MSB and LSB
+                
+                romSize = (static_cast<uint32_t>(Serial.read()) << 8);  //Reads stoppage a.k.a. the high byte of ROM size
+                if (romSize == 0) romSize = 65536;                      // Need a fix to support A17+
+                romPinCount = Serial.read();                            // Read in the ROM Pin count
+                Serial.end();                                           // Release shared pins
+                if (romPinCount == 24) latchAddress(VCC24PIN << 8);     // Enable VCC for 24 pin ROM - shift to MSB
+                if (romPinCount == 28) latchControlByte(VCC28PIN);      // Enable VCC for 28 pin ROM
+                display.clearDisplay();
+                display.print(F("Sending ROM via serial..."));
+                display.print("Blocksize: ");
+                display.print(currentCommand.blockSize);
+                display.display();
+                // loop over the total number of blocks in the ROM
+                for (int i = 0; i < romSize/currentCommand.blockSize; i++) {
+                    // Read data into buffer
+                    for (uint16_t addr = 0; addr < currentCommand.blockSize; addr++) {
+                        buffer[addr] = readAddress(cAddr);              // Read ROM data into buffer
+                        cAddr++;
+                    }
+                    delayMicroseconds(500); //Avoid framing errors - value can be tuned depending on BAUDRATE
+                    Serial.begin(BAUDRATE);                             // Open serial port
+                    Serial.write(0xAA);                                 // Transmit the frame start block indicator
+                    for (uint16_t addr = 0; addr < currentCommand.blockSize; addr++) {
+                        Serial.write(buffer[addr]);  
+                    }
+                    Serial.end();                                       // Release pins for next read cycle
+                }
+            }
+      
+            if (currentCommand.command == 0x03) {
+                byte vendor = Serial.read();
+                byte device = Serial.read();
+                uint16_t romid = (static_cast<uint16_t>(vendor) << 8) | device;
+                Serial.end();                                   // Release shared UART pins
+                display.clearDisplay();
+                display.println(F("Erasing ROM with ID: "));
+                display.println(romid, HEX);
+                display.display();
+                eraseW27C512(romid);
+                delay(3000);
+            }
+      
+            if (currentCommand.command == 0x02) { 
+                byte controlByte = 0x00;                         // initialise control byte
+                prevLSB = 0xFF;
+                prevMSB = 0xFF;
+                cAddr = 0;
+                //Burn ROM from serial
+                currentCommand.blockSize = Serial.read();        // read the blocksize
+                currentCommand.stopPage = Serial.read();         // read the stop page - currently unused!
+                romPinCount = Serial.read();                     // read the ROM pin count
+                Serial.end();                                    // Release shared pins
+                if (romPinCount == 24) {
+                    latchAddress(VCC24PIN << 8);                 // Enable 24 pin VCC - shift to MSB
+                    controlByte = (REG_DISABLE | P1_VPP_ENABLE); // Enabling P1_VPP_Enable for JP4 (Leave OPEN for 28 pin ROMs!!))
+                    PORTB &= ~(ROM_CE);                          // Make sure chip is enabled
+                }
+                if (romPinCount == 28) {
+                    controlByte = (VPE_TO_VPP | REG_DISABLE | VPE_ENABLE | VCC28PIN);
+                }
+        
+                display.clearDisplay();
+                display.println(F("Burning ROM from serial..."));
+                display.print("Blocksize: ");
+                display.print(currentCommand.blockSize);
+                display.display();
+                latchControlByte(controlByte);                   // Apply ROM control pin configuration
+                delay(200);
+                Serial.begin(BAUDRATE);                          // Open serial port
+                // Process each block of binary source file data via serial until no more bytes read
+                while (1) { 
+                    Serial.write(0xAA);                          // Send ready signal
+                    while (!Serial.available()) {                // Wait for data to arrive in the serial receive buffer
+                        ;; //Maybe we don't need it
+                    }
+                    memset(buffer, 0xFF, BUFFERSIZE);            // Clear buffer with 0xFF
+                    // Read the block of data
+                    size_t bytesRead = Serial.readBytes((char *)buffer, currentCommand.blockSize);
+                    // Check if we've read the entire block
+                    if (bytesRead > 0 && bytesRead <= currentCommand.blockSize) {
+                        // Process the buffer data
+                        Serial.end();                            // Release shared pins
+                        delayMicroseconds(20);                   // Let the serial settle
+                        writefromBuffer(cAddr, currentCommand.blockSize);
+                    } else {
+                        display.println("Bad block");
+                        break;
+                    }
+                    delayMicroseconds(20);
+                    Serial.begin(BAUDRATE);                      // Open serial port back up
+                }
+            }
+        } 
     } else {
-      display.print(".");
-      display.display();
-      delay(500);
-    }
-  */
-  } //Serial 0xAA
-
+        handleButton();
+        displayMenu();
+    /*
+    if (digitalRead(12) == 0) {
+      Serial.end();
+      enableRegulator();
+      display.println("Press RST after calibrating VEP");
+      while (1) {
+            displayVEP();
+            delay(17);
+        }
+      } else {
+        display.print(".");
+        display.display();
+        delay(500);
+      }
+    */
+    } //Serial 0xAA
 } //Loop
 
+// Enable Regulator on the RURP shield
 void enableRegulator() {
-  byte outputState = REG_DISABLE;  // Set REG_DISABLE bit
-  // Set all pins using direct port manipulation
-  latchControlByte(outputState);
+    byte outputState = REG_DISABLE;  // Set REG_DISABLE bit
+    // Set all pins using direct port manipulation
+    latchControlByte(outputState);
 }
 
+// Show VEP on oled display to facilitate manual adjustment
 void displayVEP() {
-    // Read voltage from analog pin A2
-  int sensorValue = analogRead(A2);
- // Convert ADC reading to voltage (assuming 5V reference voltage)
-  float v_in = sensorValue * (V_REF / 1023.0);
-  // Calculate voltage at VEP using voltage divider formula
-  float v_vep = v_in * (R1 + R2) / R2;
-
+    int sensorValue = analogRead(ANALOG_PIN);           // Read voltage from analog pin A2
+    float v_in = sensorValue * (V_REF / 1023.0);        // Convert ADC reading to voltage (assuming 5V reference voltage)
+    float v_vep = v_in * (R1 + R2) / R2;                // Calculate voltage at VEP using voltage divider formula
+  
     // Display voltage on OLED display
-  display.clearDisplay();
-  display.setTextSize(1);
-  display.setTextColor(SSD1306_WHITE);
-  display.setCursor(0, 0);
-  display.println(F("Press RST to return."));
-  display.print(F("VEP Voltage: "));
-  display.print(v_vep, 2); // Display voltage with 2 decimal places
-  display.println(" V");
-  display.display();
+    display.clearDisplay();
+    display.setTextSize(1);
+    display.setTextColor(SSD1306_WHITE);
+    display.setCursor(0, 0);
+    display.println(F("Press RST to return."));
+    display.print(F("VEP Voltage: "));
+    display.print(v_vep, 2);                            // Display voltage with 2 decimal places
+    display.println(" V");
+    display.display();
 }
 
 //For single byte writes 
 void writeByte(uint16_t address, byte data) {
-latchAddress(address);
-byte controlbyte = 0;
-        if (rompincount == 24) {
+    latchAddress(address);
+    byte controlbyte = 0;
+    if (romPinCount == 24) {
         controlbyte = (REG_DISABLE | P1_VPP_ENABLE); //Enabling P1_VPP_Enable for JP4 (Leave OPEN for 28 pin ROMs!!))
-        }
-        if (rompincount == 28) {
-          controlbyte = (VPE_TO_VPP | REG_DISABLE | VPE_ENABLE | VCC28PIN);
-        }
-
-latchControlByte((VPE_TO_VPP | REG_DISABLE) & controlbyte);
-delay(50); //Settle before enabling
-latchControlByte(controlbyte );
-//delay(255); //What works on 65uino
-DDRD = 0xFF; //Output
-PORTD = data; 
-PORTB &= ~(ROM_CE);
-delayMicroseconds(101);
-PORTB |= ROM_CE;
-latchControlByte(0x00); 
-}
-
-void writefromBuffer(uint16_t addr, uint16_t len) {
-  DDRD = 0xFF; //Output
-
-  // Initialise CE state for 24 pin 
-  if (rompincount == 24) {
-      PORTB &= ~(ROM_CE);                     // Ensure Chip Enable intially starts LOW for 2716 chips 
-  }
-
-  for (int i = 0; i < len; i++){
-    latchAddress(addr);
-    PORTD = buffer[i];
-    if (rompincount == 28) {
+    }
+    if (romPinCount == 28) {
+        controlbyte = (VPE_TO_VPP | REG_DISABLE | VPE_ENABLE | VCC28PIN);
+    }
+    
+    latchControlByte((VPE_TO_VPP | REG_DISABLE) & controlbyte);
+    delay(50); //Settle before enabling
+    latchControlByte(controlbyte );
+    //delay(255); //What works on 65uino
+    DDRD = 0xFF; //Output
+    PORTD = data; 
     PORTB &= ~(ROM_CE);
     delayMicroseconds(101);
-    PORTB |= ROM_CE; 
-    }
-    if (rompincount == 24) {
-    PORTB |= ROM_CE; //High pulse for 2716/TMS2516
-    delay(50);
-    PORTB &= ~(ROM_CE);
-    delay(50);                          // 50ms pulse length performs all other 24pin ROM write
-    PORTB |= ROM_CE;                    // End all other 24pin write pulse
-    PORTB &= ~(ROM_CE);                 // Return Chip Enable low in readiness for next address to be written for 2716
-    }
-    addr++;
-  } 
-  cAddr = addr;
+    PORTB |= ROM_CE;
+    latchControlByte(0x00); 
 }
 
+// Perform data write to selected ROM for the current address parameter
+void writefromBuffer(uint16_t addr, uint16_t len) {
+    DDRD = 0xFF;                                // Set all digital pins (0-7) as Outputs
+  
+    // Initialise CE state for 24 pin 
+    if (romPinCount == 24) {
+        PORTB &= ~(ROM_CE);                     // Ensure Chip Enable intially starts LOW for 2716 chips 
+    }
+    
+    // Write each buffer byte to ROM  
+    for (int i = 0; i < len; i++){
+        latchAddress(addr);
+        PORTD = buffer[i];                      // Push buffer data for cuurent address (i) onto PORTD pins
+        
+        if (romPinCount == 28) {
+            PORTB &= ~(ROM_CE);                 // Low pulse sets up ROM write for 28pin chips
+            delayMicroseconds(101);
+            PORTB |= ROM_CE;                    // Return CE to high
+        }
+        if (romPinCount == 24) {
+            PORTB |= ROM_CE;                    // High pulse allows ROM write for 2716/TMS2516
+            delay(50);                          // 50ms pulse length performs the 2716/TMS2516 ROM write
+            PORTB &= ~(ROM_CE);                 // Low pulse allows ROM write for all other 24pin chips, whilst ending 2716 pulse
+            delay(50);                          // 50ms pulse length performs all other 24pin ROM write
+            PORTB |= ROM_CE;                    // End all other 24pin write pulse
+            PORTB &= ~(ROM_CE);                 // Return Chip Enable low in readiness for next address to be written for 2716
+        }
+        addr++;
+    } 
+    cAddr = addr;
+}
+
+// erase process for W27C512 ROM chips
 void eraseW27C512(uint16_t romid) {
-if (getROMID() == romid) {
-  DDRD = 0xFF;
-  latchAddress(0x0000);
-  enableRegulator();
-  delay(100);
-  latchControlByte(A9_VPP_ENABLE | REG_DISABLE | VPE_ENABLE );
-  delay(500);
-  PORTB &= ~(ROM_CE);
-  delay(102);
-  PORTB |= ROM_CE;
-  } else {
-    display.println("ROM ID didn't match.");
-    display.display();
-  }
-  latchControlByte(0);
+    if (getROMID() == romid) {
+        DDRD = 0xFF;                    // Set all digital pins (0-7) as Outputs
+        latchAddress(0x0000);
+        enableRegulator();
+        delay(100);
+        latchControlByte(A9_VPP_ENABLE | REG_DISABLE | VPE_ENABLE );
+        delay(500);
+        PORTB &= ~(ROM_CE);
+        delay(102);
+        PORTB |= ROM_CE;
+    } else {
+        display.println("ROM ID didn't match.");
+        display.display();
+    }
+    latchControlByte(0);
 }
 
+// Retrieve the ROM Identification
 uint16_t getROMID() {
-  enableRegulator();
-  // Introduce a delay before repeating the process
-  delay(50); // Adjust delay time as needed
-  latchControlByte(VPE_TO_VPP | REG_DISABLE | A9_VPP_ENABLE );
-  delay(50);
-  byte byteRead = readAddress(0x0000);
-  uint16_t romid = byteRead;
-  romid = romid <<8;
-  byteRead = readAddress(0x0001);
-  romid |= byteRead;
-  latchControlByte(0);
-return romid;
+    enableRegulator();
+    // Introduce a delay before repeating the process
+    delay(50); // Adjust delay time as needed
+    latchControlByte(VPE_TO_VPP | REG_DISABLE | A9_VPP_ENABLE );
+    delay(50);
+    byte byteRead = readAddress(0x0000);
+    uint16_t romid = byteRead;
+    romid = romid <<8;
+    byteRead = readAddress(0x0001);
+    romid |= byteRead;
+    latchControlByte(0);
+    return romid;
 }
 
+// Read a 16-bit address from the ROM and return the value
 byte readAddress(uint16_t addr) {
-  DDRD = 0xFF; 
-  latchAddress(addr);
-  DDRD = 0; //PORTD as input
-  PORTB &= ~(ROM_OE | ROM_CE);
-  delayMicroseconds(20); //Let it settle a bit. Maybe a NOP would do. 
-  byte val = PIND;
-  PORTB |= (ROM_OE); //Leave CE low
-  return val;
+    DDRD = 0xFF;                                // Set all digital pins (0-7) as Output
+    latchAddress(addr);                         // Set the address pins
+    DDRD = 0x00;                                // Set all digital pins (0-7) as Input
+    PORTB &= ~(ROM_OE | ROM_CE);                // Set pins Output Enable and Chip Enable LOW 
+    delayMicroseconds(20);                      // Let Address/Data settle 
+    byte val = PIND;                            // Read the value from all digital output pins
+    PORTB |= (ROM_OE);                          // Set Output Enable HIGH, leave CE LOW
+    return val;
 }
 
+// Push a 8-bit value onto the arduino D0-D7 pins and latch
 void latchControlByte(byte controlByte) {
-  //Enable VCC for 28 pin ROMs
-  if (rompincount == 28) controlByte |= VCC28PIN;
-
-  // Set control byte using direct port manipulation
-  DDRD  = 0xFF ; // All output
-  PORTD = controlByte;
-
-// Set CTRL_LE pin HIGH to latch
-  PORTB |= CTRL_LE;
-  // Set CTRL_LE pin LOW to unlatch
-  PORTB &= ~(CTRL_LE);
+    if (romPinCount == 28) controlByte |= VCC28PIN; //Enable VCC for 28 pin ROMs
+  
+    DDRD = 0xFF;                                    // Set all digital pins (0-7) as Output
+    PORTD = controlByte;                            // Push the control value onto the pins
+  
+    PORTB |= CTRL_LE;                               // Set CTRL_LE pin HIGH to latch
+    PORTB &= ~(CTRL_LE);                            // Set CTRL_LE pin LOW to unlatch
 }
 
+// Push a 16-bit address onto the arduino D0-D7 pins for the each upper/lower byte
 void latchAddress(uint16_t address) {
-  // Extract the least significant byte
-  byte lsb = address & 0xFF;
-  // Extract the most significant byte
-  byte msb = (address >> 8) & 0xFF;
-  //Assuming PORTD is output
-  // Check if LSB has changed
-  if (lsb != prevLSB) {
-    // Write LSB to PORTD
-    PORTD = lsb;
-    // Set CTRL_LE pin HIGH to latch lower 8 bits of address (LSB)
-    PORTB |= RLSBLE;
-    // Set RLSBLE pin LOW to unlatch lower 8 bits of address (LSB)
-    PORTB &= ~RLSBLE;
-    // Update prevLSB
-    prevLSB = lsb;
-  }
+    byte lsb = address & 0xFF;                      // Extract the least significant byte
+    byte msb = (address >> 8) & 0xFF;               // Extract the most significant byte
 
-  // Check if MSB has changed
-  if (msb != prevMSB) {
-    // Update prevMSB before ORing in VCC for 24pin ROMs, otherwise above check will always be true
-    prevMSB = msb;
-    if (rompincount == 24) {
-    msb |= 0b00100000; //Enable VCC on "A13"
+    // Check if LSB has changed
+    if (lsb != prevLSB) {
+        PORTD = lsb;                                // Write LSB address to PORTD pins
+        PORTB |= RLSBLE;                            // Set RLSBLE pin HIGH to latch lower 8 bits of address (LSB)
+        PORTB &= ~RLSBLE;                           // Set RLSBLE pin LOW to unlatch lower 8 bits of address (LSB)
+        prevLSB = lsb;                              // Update prevLSB
     }
-    // Write MSB to PORTD
-    PORTD = msb;
-    // Set RMSBLE pin HIGH to latch higher 8 bits of address (MSB)
-    PORTB |= RMSBLE;
-    // Set RMSBLE pin LOW to unlatch higher 8 bits of address (MSB)
-    PORTB &= ~RMSBLE;
-  }
+  
+    // Check if MSB has changed
+    if (msb != prevMSB) {
+        prevMSB = msb;                              // Update prevMSB before ORing in VCC for 24pin ROMs, otherwise above check will always be true
+        
+        if (romPinCount == 24) {
+            msb |= VCC24PIN;                        // Enable VCC on "A13"
+        }
+        PORTD = msb;                                // Write MSB address to PORTD pins
+        PORTB |= RMSBLE;                            // Set RMSBLE pin HIGH to latch higher 8 bits of address (MSB)
+        PORTB &= ~RMSBLE;                           // Set RMSBLE pin LOW to unlatch higher 8 bits of address (MSB)
+    }
 }
 
+// When USR button is pressed, process menu cycle (short press) or menu selection (long press)
 void handleButton() {
-  if(digitalRead(12) == LOW) {
-    if (!buttonPressed) {
-      buttonPressed = true;
-      buttonPressTime = millis();
+    if(digitalRead(12) == LOW) {
+        if (!buttonPressed) {
+            buttonPressed = true;
+            buttonPressTime = millis();
+        } else {
+            if (millis() - buttonPressTime > LONG_PRESS_TIME) {
+                // Long press detected
+                buttonPressed = false;      // Reset button state
+                handleSelection(menuIndex);
+                Serial.begin(BAUDRATE);     // Open serial port 
+                delay(500);                 // Prevent multiple triggers
+            }
+        }
     } else {
-      if (millis() - buttonPressTime > LONG_PRESS_TIME) {
-        // Long press detected
-        buttonPressed = false;  // Reset button state
-        handleSelection(menuIndex);
-        Serial.begin(baudrate);
-        delay(500);  // Prevent multiple triggers
-      }
+        if (buttonPressed) {
+            if (millis() - buttonPressTime < LONG_PRESS_TIME) {
+                // Short press detected
+                menuIndex++;
+                if (menuIndex >= MENU_ITEM_COUNT) menuIndex = 0;
+            }
+            buttonPressed = false;          // Reset button state
+        }
     }
-  } else {
-    if (buttonPressed) {
-      if (millis() - buttonPressTime < LONG_PRESS_TIME) {
-        // Short press detected
-        menuIndex++;
-        if (menuIndex >= menuItemsCount) menuIndex = 0;
-      }
-      buttonPressed = false;  // Reset button state
-    }
-  }
 }
 
+// Show Menu options and highlight currently selected item
 void displayMenu() {
-  display.clearDisplay();
-  for(int i = 0; i < menuItemsCount; i++) {
-    if(i == menuIndex) {
-      display.setTextColor(SSD1306_BLACK, SSD1306_WHITE); // Highlight selected item
-    } else {
-      display.setTextColor(SSD1306_WHITE);
+    display.clearDisplay();
+    for(int i = 0; i < MENU_ITEM_COUNT; i++) {
+        if(i == menuIndex) {
+            display.setTextColor(SSD1306_BLACK, SSD1306_WHITE); // Highlight selected item
+        } else {
+            display.setTextColor(SSD1306_WHITE);
+        }
+        display.setCursor(0, i*10);
+        display.println(MENU_ITEMS[i]);
     }
-    display.setCursor(0, i*10);
-    display.println(menuItems[i]);
-  }
-  display.display();
+    display.display();
 }
 
-
+// Process menu action based on USR button selection index parameter
 void handleSelection(int index) {
-  //Calibrate VEP", "Display ROM ID", "Blank check ROM", "Erase W27C512"
-  switch (index) {
-    case 0:
-          Serial.end();
-          enableRegulator();
-          while (1) {
+    switch (index) {
+        case 0: // Calibrate VEP
+            Serial.end();                           // Release shared UART pins
+            enableRegulator();
+            while (1) {                             // Infinite Loop!! - Perhaps change to while until USRBTN pressed
                 display.println(F("Press RST after calibrating VEP"));
                 displayVEP();
                 delay(17);
             }
-      break;
-    case 1:
-          Serial.end();
-      display.clearDisplay();
-      display.setCursor(0,0);
-      display.print(F("Read ROM ID: "));
-      display.println(getROMID(),HEX);
-      display.display();
-           delay(3000);
-      break;
-    case 2:
-     Serial.end();
-     display.clearDisplay();
-     display.setCursor(0,0);
-     if (blankCheck() == 0) display.println("ROM is blank");
-     display.display();
-     delay(3000);
-      break;
-    case 3:
-     Serial.end();
-     display.clearDisplay();
-     display.setCursor(0,0);
-     display.println("Erasing ROM with ID 0xDA08 ");
-     eraseW27C512(0xDA08);
-     display.display();
-     delay(3000);
-      break;
-    default:
-      break;
-  }
+            break;
+        case 1: // Display ROM ID
+            Serial.end();                           // Release shared UART pins
+            display.clearDisplay();
+            display.setCursor(0,0);
+            display.print(F("Read ROM ID: "));
+            display.println(getROMID(),HEX);
+            display.display();
+            delay(3000);
+            break;
+        case 2: // Blank check ROM
+            Serial.end();                           // Release shared UART pins
+            display.clearDisplay();
+            display.setCursor(0,0);
+            if (blankCheck() == 0) display.println("ROM is blank");
+            display.display();
+            delay(3000);
+            break;
+        case 3: // Erase W27C512
+            Serial.end();                           // Release shared UART pins
+            display.clearDisplay();
+            display.setCursor(0,0);
+            display.println("Erasing ROM with ID 0xDA08 ");
+            eraseW27C512(0xDA08);
+            display.display();
+            delay(3000);
+            break;
+        default:
+            break;
+    }
 }
 
+// check if ROM is blank, return 1 if not blank otherwise return 0
 uint16_t blankCheck () {
-  display.clearDisplay();
-  display.println(F("Checking if ROM is blank.."));
-  display.display();
-  uint32_t i;
-  for (i = 0; i < 65537; i++) {
-    byte data = readAddress(i);
-    if (data != 0xFF) {
-      display.print(data,HEX);
-      display.print(" found at address ");
-      display.println(i, HEX);
-      display.display();
-      return 1;
-    } 
-  }
-  if (i == 65537) i = 0;
-  return i;
+    display.clearDisplay();
+    display.println(F("Checking if ROM is blank.."));
+    display.display();
+    uint32_t i;
+    for (i = 0; i < 65537; i++) {
+        byte data = readAddress(i);
+        if (data != 0xFF) {
+            display.print(data,HEX);
+            display.print(" found at address ");
+            display.println(i, HEX);
+            display.display();
+            return 1;               // Not blank
+        } 
+    }
+    if (i == 65537) i = 0;
+    return i;                       // blank
 }

--- a/software/Arduino/ArduinoProgrammerFirmwarePrototype/ArduinoProgrammerFirmwarePrototype.ino
+++ b/software/Arduino/ArduinoProgrammerFirmwarePrototype/ArduinoProgrammerFirmwarePrototype.ino
@@ -47,9 +47,13 @@ const int ANALOG_PIN = A2; // Analog pin connected to VEP
 
 uint32_t romsize = 4096; //We need to support more than 16 address bits
 byte pattern = 0xAA;
+// Global variables to store the previous LSB and MSB values
+byte prevLSB = 0xFF;
+byte prevMSB = 0xFF;
 uint16_t cAddr = 0;
-byte buffer[128]; 
 #define BUFFERSIZE 128
+byte buffer[BUFFERSIZE]; 
+
 byte rompincount = 28; 
 
 uint32_t baudrate = 19200;
@@ -158,6 +162,9 @@ void loop() {
 
       if (currentCommand.command == 0x02) { 
         byte controlbyte = 0;
+        prevLSB = 0xFF;
+        prevMSB = 0xFF;
+        cAddr = 0;
         //Burn ROM from serial
         currentCommand.blockSize = Serial.read();
         currentCommand.stopPage = Serial.read();
@@ -177,8 +184,6 @@ void loop() {
         display.print("Blocksize: ");
         display.print(currentCommand.blockSize);
         display.display();
-        latchControlByte((VPE_TO_VPP | REG_DISABLE | VCC28PIN ) & controlbyte);
-        delay(50); //Settle before enabling
         latchControlByte(controlbyte); //Burn ROM config
         delay(200);
         Serial.begin(baudrate);
@@ -187,10 +192,11 @@ void loop() {
           while (!Serial.available()) { 
           ;; //Maybe we don't need it
            }
+          memset(buffer, 0xFF, BUFFERSIZE);            // Clear buffer with 0xFF
           // Read the block of data
           size_t bytesRead = Serial.readBytes((char *)buffer, currentCommand.blockSize);
             // Check if we've read the entire block
-          if (bytesRead == currentCommand.blockSize) {
+          if (bytesRead > 0 && bytesRead <= currentCommand.blockSize) {
             // Process the buffer data
            Serial.end();
            delayMicroseconds(20);
@@ -277,18 +283,27 @@ latchControlByte(0x00);
 
 void writefromBuffer(uint16_t addr, uint16_t len) {
   DDRD = 0xFF; //Output
+
+  // Initialise CE state for 24 pin 
+  if (rompincount == 24) {
+      PORTB &= ~(ROM_CE);                     // Ensure Chip Enable intially starts LOW for 2716 chips 
+  }
+
   for (int i = 0; i < len; i++){
     latchAddress(addr);
     PORTD = buffer[i];
-    if (rompincount = 28) {
+    if (rompincount == 28) {
     PORTB &= ~(ROM_CE);
     delayMicroseconds(101);
     PORTB |= ROM_CE; 
     }
-    if (rompincount = 24) {
+    if (rompincount == 24) {
     PORTB |= ROM_CE; //High pulse for 2716/TMS2516
     delay(50);
     PORTB &= ~(ROM_CE);
+    delay(50);                          // 50ms pulse length performs all other 24pin ROM write
+    PORTB |= ROM_CE;                    // End all other 24pin write pulse
+    PORTB &= ~(ROM_CE);                 // Return Chip Enable low in readiness for next address to be written for 2716
     }
     addr++;
   } 
@@ -353,10 +368,6 @@ void latchControlByte(byte controlByte) {
   PORTB &= ~(CTRL_LE);
 }
 
-// Global variables to store the previous LSB and MSB values
-byte prevLSB = 1;
-byte prevMSB = 1;
-
 void latchAddress(uint16_t address) {
   // Extract the least significant byte
   byte lsb = address & 0xFF;
@@ -377,6 +388,8 @@ void latchAddress(uint16_t address) {
 
   // Check if MSB has changed
   if (msb != prevMSB) {
+    // Update prevMSB before ORing in VCC for 24pin ROMs, otherwise above check will always be true
+    prevMSB = msb;
     if (rompincount == 24) {
     msb |= 0b00100000; //Enable VCC on "A13"
     }
@@ -386,8 +399,6 @@ void latchAddress(uint16_t address) {
     PORTB |= RMSBLE;
     // Set RMSBLE pin LOW to unlatch higher 8 bits of address (MSB)
     PORTB &= ~RMSBLE;
-    // Update prevMSB
-    prevMSB = msb;
   }
 }
 


### PR DESCRIPTION
# Arduino Relatively Universal ROM Programmer - Fixes and Improvements

## Overview

This PR introduces a series of fixes and improvements to the Arduino Relatively Universal ROM Programmer sketch. The changes address several functional bugs in the ROM-burning logic, improve consistency and maintainability, simplify key control paths, and enhance the reliability of the burn and dump operations. The updates are grouped logically across several commits covering bug fixes, formatting, restructuring, performance improvements, and general cleanup.

> **Note:** It is highly recommended that the majority of Relatively Universal ROM Programmer users utilize the Firestarter firmware which offers a far more robust solution. However, there are some ROMs that are not yet supported in Firestarter, such as 2716.

The overall aim is to make the codebase more robust, easier to follow, and more predictable when handling a range of supported ROM types as well as enabling easier future prototyping of more obscure ROMs that may not currently have support in FireStarter.

---

## Key Changes

### 1. Bug Fixes and Reliability Improvements

#### ROM addressing and write logic
- Corrected `latchAddress()` MSB handling by updating `prevMSB` before OR'ing in VCC for 24-pin ROMs
- Resolved multiple missing `==` operators in address width detection within `writeFromBuffer()`
- Improved 24-pin CE handling to ensure 2716 chips initialise and complete correctly
- Ensured final short blocks are handled safely without merging with previous cached data

#### Globals and initial state
- Reorganised global variable placement and ensured `prevLSB`/`prevMSB` are initialised to `0xFF`
- Tidied `BUFFERSIZE` and ensured it's used consistently for buffer sizing

#### Burn routine
- Reset `prevLSB`, `prevMSB`, buffer contents, and write-entry conditions inside burn logic to avoid stale-state bugs

---

### 2. Standardised Formatting and Naming
- Adopted consistent formatting across the whole sketch
- Replaced `#define` usage with type-safe constants
- Standardised naming conventions (constants uppercase, variables camelCase)
- Added clarifying comments throughout
- Ensured uniform use of `0x00` and `0xFF` for all byte variables
- Introduced a named constant for the 24-pin VCC bitmask and eliminated hard-coded `0x2000`

---

### 3. Structural Improvements
- Introduced named command constants for `dumpROM`, `burnROM`, and `eraseROM`
- Refactored the main loop so that each major command has its own dedicated function
- Added an initial pin-state reset function to ensure a predictable hardware state before and after each command. This removes the need to 'reset' after each burn/dump/erase, changes include:
  - Clearing all pin states
  - Resetting `cAddr`, `prevLSB`, `prevMSB`
  - Restoring DDR configurations
  - Resetting PORTD defaults

---

### 4. Expanded Validation, Error Handling, and Performance Enhancements

#### `burnROM` improvements
- Added explicit end-of-file detection using a new `EOF_BYTE`
- Added blocksize validation
- Implemented improved error tracking and a `dataProcessed` indicator
- Ensured the burn operation cannot hang after file transfer completes
- Added `serial.flush()` where appropriate

#### `dumpROM` improvements
- Added blocksize validation
- Fixed block rounding to ensure remaining bytes form a final block
- Send each block as a complete buffer write rather than single bytes

#### General
- Added named constants for startup delays, settle times, and maximum ROM size
- Corrected and simplified blank-checking logic
- Added additional timing delays where required
- Improved Python `send_binary` helper script:
  - Increased timeout to avoid premature serial timeouts
  - Added block reporting output
  - Added error counting and suppression of unintended zero bytes caused by D0/D1 states
  - Added transfer timing output

---

### 5. Cleanup and Removal of Redundancy
- Removed unused `writeByte()` as `writeFromBuffer()` supports single-byte writes
- Removed outdated or commented-out logic from the main loop
- Replaced infinite-loop constructs with standard `while(1)` pattern
- Removed leftover commentary around OLED initialisation

---

## Caveats

⚠️ **Testing Limitations:**

- I have only tested **HN462716G (Hitachi) EPROMs**, though the specification appears identical to other common 2716 chips
- I don't have a display connected to my Relatively Universal ROM Programmer. As a result I've been hesitant in changing anything connected to the display functionality, the only exceptions being formatting and comments
- I do not own any **28-pin ROMs** and so I have not been able to apply regression testing for them following the overhaul to the code. However, I've tried to be mindful in minimising any impact in the changes to the support of these ROMs. Likewise I've been hesitant to make any changes to functions that relate to erasing these chips or associated functions such as ROM ID

---

## Summary

These changes significantly improve the sketch's reliability, clarity, and consistency while preserving existing behaviour for all supported ROM types. The improvements should help users achieve more predictable burns and dumps, and make future development easier.

**Feedback welcome!** Happy to discuss or adjust any detail.